### PR TITLE
feat: add cap-collaborative-draft, cap-snowflake, cap-plugin-adobe-forms

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -378,5 +378,21 @@
     "type": "plugin",
     "tags": ["segw", "abap", "generator", "odata", "odatav2", "odatav4", "plugin"],
     "license": "apache-2.0"
+  },
+  {
+    "owner": "sleibach",
+    "repo": "cap-collaborative-draft",
+    "addedToBoUI5": "2026-05-11T20:00:00.000Z",
+    "type": "plugin",
+    "tags": ["cds", "cap", "fiori", "draft", "collaborative"],
+    "license": "apache-2.0"
+  },
+  {
+    "owner": "sleibach",
+    "repo": "cap-snowflake",
+    "addedToBoUI5": "2026-05-11T21:00:00.000Z",
+    "type": "plugin",
+    "tags": ["sap", "cap", "cds", "snowflake", "database", "adapter", "odata"],
+    "license": "apache-2.0"
   }
 ]

--- a/sources.json
+++ b/sources.json
@@ -394,5 +394,13 @@
     "type": "plugin",
     "tags": ["sap", "cap", "cds", "snowflake", "database", "adapter", "odata"],
     "license": "apache-2.0"
+  },
+  {
+    "owner": "salvatorelaspata",
+    "repo": "cap-plugin-adobe-forms",
+    "addedToBoUI5": "2026-04-25T16:42:57.868Z",
+    "type": "plugin",
+    "tags": ["adobeform", "btp", "sap", "plugin"],
+    "license": "mit"
   }
 ]


### PR DESCRIPTION
Adds three new packages to `sources.json` based on community requests:

- `sleibach/cap-collaborative-draft` (plugin)
- `sleibach/cap-snowflake` (database adapter plugin)
- `salvatorelaspata/cap-plugin-adobe-forms` (plugin — corrects the `owner` typo from PR #18 where it was set to `salvatorela`)

JSON validated locally.

Closes #17
Closes #19
Closes #20

Supersedes #18.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4u7HxW6fXeLuejpDgs4sA)_