### PR TITLE
feat: add cap-n8n

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -396,6 +396,14 @@
     "license": "apache-2.0"
   },
   {
+    "owner": "sleibach",
+    "repo": "cap-n8n",
+    "addedToBoUI5": "2026-06-15T20:18:58.000Z",
+    "type": "plugin",
+    "tags": ["cap", "cds", "n8n", "workflow", "automation", "sap"],
+    "license": "apache-2.0"
+  },
+  {
     "owner": "salvatorelaspata",
     "repo": "cap-plugin-adobe-forms",
     "addedToBoUI5": "2026-04-25T16:42:57.868Z",


### PR DESCRIPTION
## Summary
- add `sleibach/cap-n8n` to `sources.json`
- classify it as a CAP plugin with n8n workflow automation tags
- use the package metadata license value `apache-2.0`

## Validation
- `jq empty sources.json`
- duplicate check for exactly one `sleibach/cap-n8n` entry
- `git diff --check HEAD~1 HEAD`
- `./node_modules/typescript/bin/tsc --noEmit`

Closes #22
